### PR TITLE
Fix UnpackError message

### DIFF
--- a/axcell/helpers/paper_extractor.py
+++ b/axcell/helpers/paper_extractor.py
@@ -33,7 +33,7 @@ class PaperExtractor:
         try:
             self.unpack(source, unpack_path)
         except UnpackError as e:
-            if e.message.startswith('The paper has been withdrawn'):
+            if e.args[0].startswith('The paper has been withdrawn'):
                 return 'withdrawn'
             return 'no-tex'
         html_path = self.root / 'htmls' / subpath / 'index.html'


### PR DESCRIPTION
## Problem
  File "*/axcell/helpers/paper_extractor.py", line 38, in __call__
    if e.message.startswith('The paper has been withdrawn'):
AttributeError: 'UnpackError' object has no attribute 'message'
## Reason
BaseException.message has been deprecated as of Python 2.6
## Reference

1. [BaseException.message deprecated in Python 2.6](https://stackoverflow.com/questions/1272138/baseexception-message-deprecated-in-python-2-6)
2. [Proper way to declare custom exceptions in modern Python?](https://stackoverflow.com/questions/1319615/proper-way-to-declare-custom-exceptions-in-modern-python/26938914#26938914)