### PR TITLE
adding pip dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
+- pip=21.0.1
 - fire=0.1.3
 - html5lib=1.0.1
 - beautifulsoup4=4.7.1


### PR DESCRIPTION
when installing without explicit pip dependency, conda gives:

> Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.

added pip to the environment.yaml to fix that.